### PR TITLE
fix for 1.1.0 (?)

### DIFF
--- a/src/Mission/ArrowCamMissionView.cs
+++ b/src/Mission/ArrowCamMissionView.cs
@@ -42,7 +42,7 @@ namespace ArrowCam
             if (Input.IsKeyDown(InputKey.MiddleMouseButton))
             {
                 // Currently disable ballistas
-                foreach (SiegeWeapon sw in Mission.Current.ActiveMissionObjects.FindAllWithType<SiegeWeapon>())
+                foreach (SiegeWeapon sw in Mission.ActiveMissionObjects.FindAllWithType<SiegeWeapon>())
                     if (sw.PilotAgent == Agent.Main && sw is Ballista)
                         return;
 


### PR DESCRIPTION
Seems to have fixed the "Method not found: 'System.Collections.Generic.IReadOnlyList`1 TaleWorlds.MountAndBlade.Mission.get_ActiveMissionObjects()'." crash.
Only tested it briefly (one field battle vs looters), so I don't know if it works for all battle types (sieges in particular), but at least it didn't crash on battle startup.
[ArrowCam.zip](https://github.com/Eskalior/BannerlordArrowCam/files/11779766/ArrowCam.zip)
Also, here's the version I compiled for myself before creating a PR.
